### PR TITLE
Add a "global" package named "on-lisp"

### DIFF
--- a/on-lisp.asd
+++ b/on-lisp.asd
@@ -58,7 +58,8 @@
                                               "chapter-22"))
              (:file "chapter-25" :depends-on ("package"
                                               "chapter-04")))))
-  :depends-on (cl-reexport))
+  :depends-on (cl-reexport
+               named-readtables))
 
 (defsystem :on-lisp-test
   :depends-on (:on-lisp :stefil :lisp-unit :named-readtables)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -286,9 +286,12 @@
 
 (defpackage :on-lisp.17
   (:use :cl)
+  (:import-from :named-readtables
+                :defreadtable)
   (:export
    #:defdelim
    #:ddfn
+   #:read-macros
    ))
 
 (defpackage :on-lisp.18


### PR DESCRIPTION
This pull creates a package called `on-lisp` and reexports (using [cl-reexport](https://github.com/takagi/cl-reexport)) all symbols from all other packages, except packages with more than one version of a symbol, like 19, 24 and 25.

With this, one can say:

``` lisp
(defpackage :my-package
  (:use cl)
  (:import-from on-lisp
                mapa-b
                symb
                with-gensyms
                while
                ...))
```

...instead of:

``` lisp
(defpackage :my-package
  (:use cl)
  (:import-from on-lisp.04
                mapa-b
                symb)
  (:import-from on-lisp.11
                with-gensyms)
  (:import-from :on-lisp.07
                while)
  ...)
```
