### PR TITLE
Added DECLARE IGNORABLE declaration to anaphoric macro

### DIFF
--- a/src/chapter-16.lisp
+++ b/src/chapter-16.lisp
@@ -141,7 +141,7 @@
       (let ((sym (gensym)))
         `(let* ((,sym ,(car args))
                 (it ,sym))
-           (declare (ignorable it))
+           (declare (ignorable it)) ;; not in the original version
            ,(anaphex1 (cdr args)
                       (append call (list sym)))))
       call))

--- a/src/chapter-16.lisp
+++ b/src/chapter-16.lisp
@@ -141,6 +141,7 @@
       (let ((sym (gensym)))
         `(let* ((,sym ,(car args))
                 (it ,sym))
+           (declare (ignorable it))
            ,(anaphex1 (cdr args)
                       (append call (list sym)))))
       call))


### PR DESCRIPTION
Added the declaration in order to supress warnings of unused variable in the macro.