### PR TITLE
Add defdelim for non-dispatching read-macros

### DIFF
--- a/src/chapter-17.lisp
+++ b/src/chapter-17.lisp
@@ -78,7 +78,7 @@
         (apply fn
                (read-delimited-list right stream t))))))
 
-;;#+nil
+#+nil
 (defdelim# #\[ #\] (x y)
   (list 'quote (mapa-b #'identity (ceiling x) (floor y))))
 

--- a/src/chapter-17.lisp
+++ b/src/chapter-17.lisp
@@ -56,8 +56,8 @@
       (push i accum))))
 
 ;; p. 228
-(defmacro defdelim# (left right params &body body)
-  `(ddfn# ,left ,right (lambda ,params ,@body)))
+(defmacro defdelim# (left right parms &body body)
+  `(ddfn# ,left ,right (lambda ,parms ,@body)))
 
 (defmacro defdelim (left right parms &body body)
   `(ddfn ,left ,right (lambda ,parms ,@body)))
@@ -66,19 +66,22 @@
   (defun ddfn# (left right fn)
     (set-macro-character right rpar)
     (set-dispatch-macro-character #\# left
-      (lambda (stream char)
-        (declare (ignore char))
+      (lambda (stream char1 char2)
+        (declare (ignore char1 char2))
         (apply fn
                (read-delimited-list right stream t)))))
   (defun ddfn (left right fn)
     (set-macro-character right rpar)
     (set-macro-character left
-      (lambda (stream char1 char2)
-        (declare (ignore char1 char2))
+      (lambda (stream char)
+        (declare (ignore char))
         (apply fn
                (read-delimited-list right stream t))))))
 
-#+nil
+;;#+nil
+(defdelim# #\[ #\] (x y)
+  (list 'quote (mapa-b #'identity (ceiling x) (floor y))))
+
 (defdelim #\[ #\] (x y)
   (list 'quote (mapa-b #'identity (ceiling x) (floor y))))
 

--- a/src/chapter-17.lisp
+++ b/src/chapter-17.lisp
@@ -56,15 +56,25 @@
       (push i accum))))
 
 ;; p. 228
+(defmacro defdelim# (left right params &body body)
+  `(ddfn# ,left ,right (lambda ,params ,@body)))
+
 (defmacro defdelim (left right parms &body body)
   `(ddfn ,left ,right (lambda ,parms ,@body)))
 
 (let ((rpar (get-macro-character #\))))
+  (defun ddfn# (left rigth fn)
+    (set-macro-character right rpar)
+    (set-dispatch-macro-character left
+      (lambda (stream char)
+        (declare (ignore char))
+        (apply fn
+               (read-delimited-list right stream t)))))
   (defun ddfn (left right fn)
     (set-macro-character right rpar)
-    (set-dispatch-macro-character #\# left
+    (set-macro-character left
       (lambda (stream char1 char2)
-        (declare (ignore char1 char2))
+        (declare (ignore char1))
         (apply fn
                (read-delimited-list right stream t))))))
 

--- a/src/chapter-17.lisp
+++ b/src/chapter-17.lisp
@@ -82,12 +82,9 @@
 (defdelim# #\[ #\] (x y)
   (list 'quote (mapa-b #'identity (ceiling x) (floor y))))
 
-(defdelim #\[ #\] (x y)
-  (list 'quote (mapa-b #'identity (ceiling x) (floor y))))
-
 ;; p. 229
 #+nil
-(defdelim #\{ #\} (&rest args)
+(defdelim# #\{ #\} (&rest args)
   `(fn (compose ,@args)))
 
 ;;; Changed from anonymous lambda to |#{-reader| to support named-readtables

--- a/src/chapter-17.lisp
+++ b/src/chapter-17.lisp
@@ -63,7 +63,7 @@
   `(ddfn ,left ,right (lambda ,parms ,@body)))
 
 (let ((rpar (get-macro-character #\))))
-  (defun ddfn# (left rigth fn)
+  (defun ddfn# (left right fn)
     (set-macro-character right rpar)
     (set-dispatch-macro-character #\# left
       (lambda (stream char)
@@ -74,7 +74,7 @@
     (set-macro-character right rpar)
     (set-macro-character left
       (lambda (stream char1 char2)
-        (declare (ignore char1))
+        (declare (ignore char1 char2))
         (apply fn
                (read-delimited-list right stream t))))))
 

--- a/src/chapter-17.lisp
+++ b/src/chapter-17.lisp
@@ -65,7 +65,7 @@
 (let ((rpar (get-macro-character #\))))
   (defun ddfn# (left rigth fn)
     (set-macro-character right rpar)
-    (set-dispatch-macro-character left
+    (set-dispatch-macro-character #\# left
       (lambda (stream char)
         (declare (ignore char))
         (apply fn


### PR DESCRIPTION
I separated the original `defdelim` into two:
- `defdelim#`: the original `defdelim`
- `defdelim`: the equivalent of the original `defdelim` but using `set-macro-character` instead of `set-dispatch-macro-character`.

The naming may confuse someone looking too fast. The names explain better the differences, but differ from the book.

What do you think?
